### PR TITLE
Allowing '@' as leading character in identifier

### DIFF
--- a/runtime/dsl/ast_test.go
+++ b/runtime/dsl/ast_test.go
@@ -37,7 +37,7 @@ func TestEscapeString(t *testing.T) {
 func TestParseString(t *testing.T) {
 	nodes, err := ParseString(string(script))
 	assert.NoError(t, err)
-	expectedTypes := []AstType{SOURCE, SOURCE, MERGE, DUPE, APPEND, CUT, FANOUT, TAG, JOIN, SINK, ASYNC_SINK}
+	expectedTypes := []AstType{SOURCE, SOURCE, MERGE, DUPE, APPEND, CUT, FANOUT, TAG, EOL, JOIN, SINK, ASYNC_SINK}
 	assert.Len(t, nodes, len(expectedTypes))
 
 	for i := 0; i < len(expectedTypes); i++ {

--- a/runtime/dsl/lexbuf.go
+++ b/runtime/dsl/lexbuf.go
@@ -127,6 +127,9 @@ func (b *lexBuf) readUntilWhitespaceOrBreak() error {
 	for {
 		c, err := b.read()
 		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
 			return err
 		}
 		switch {

--- a/runtime/dsl/lexer.go
+++ b/runtime/dsl/lexer.go
@@ -45,7 +45,7 @@ const (
 const (
 	alpha       = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	number      = "0123456789"
-	idStart     = alpha
+	idStart     = alpha + "@"
 	idRemainder = alpha + number + "_"
 )
 
@@ -95,11 +95,11 @@ func (l *lexer) postToken(t lexType) {
 }
 
 func (l *lexer) handleLexErr(err error) {
-	l.err = err
 	if err == io.EOF {
 		l.tokens <- token{Pos: l.pos, Line: l.line, Text: "", Type: tEof}
 		return
 	}
+	l.err = err
 	text := l.consume()
 	text = ": '" + text + "'"
 	l.tokens <- token{Pos: l.pos, Line: l.line, Text: err.Error() + text, Type: tErr}

--- a/runtime/dsl/lexer_test.go
+++ b/runtime/dsl/lexer_test.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	_ "embed"
+	"github.com/saylorsolutions/nomlog/pkg/entries"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"os"
@@ -47,6 +48,19 @@ func TestLexer_Lex(t *testing.T) {
 	}
 }
 
+func TestLexIdentifierWithLeadingAt(t *testing.T) {
+	l := lexString(entries.StandardMessageField)
+	go l.lex()
+	tokens := consume(l.tokens)
+	assert.NoError(t, l.err)
+
+	expected := []lexType{tIdentifier, tEof}
+	assert.Len(t, tokens, len(expected))
+	for i, tok := range tokens {
+		assert.Equalf(t, expected[i], tok.Type, "token %d mismatch: %s", i, tok.Text)
+	}
+}
+
 //go:embed test
 var script []byte
 
@@ -76,6 +90,7 @@ func TestLexFile(t *testing.T) {
 		tCut, tWith, tString, tIdentifier, tSet, tLpar, tIdentifier, tEq, tInt, tComma, tIdentifier, tEq, tInt, tRpar, tEol,
 		tFanout, tIdentifier, tAs, tIdentifier, tAnd, tIdentifier, tEol,
 		tTag, tIdentifier, tWith, tString, tEol,
+		tEol,
 		tJoin, tIdentifier, tWith, tString, tComma, tString, tEol,
 		tSink, tIdentifier, tTo, tIdentifier, tDot, tIdentifier, tString, tEol,
 		tSink, tIdentifier, tAsync, tAs, tIdentifier, tTo, tIdentifier, tDot, tIdentifier, tString, tEol,

--- a/runtime/dsl/test
+++ b/runtime/dsl/test
@@ -6,6 +6,7 @@ append e to f
 cut with " " f set(field1 = 0, field2 = -1)
 fanout f as g and h
 tag g with "important"
+
 join g with "^leading text", "^other pattern"
 sink g to file.File "file3.log"
 sink h async as i to    file.File "file4.log"


### PR DESCRIPTION
 - Fixing bug where encountering an EOF in readUntilWhitespaceOrBreak will erroneously fail the read.

Resolves #2 